### PR TITLE
Rename dataset to index

### DIFF
--- a/src/opperai/types/__init__.py
+++ b/src/opperai/types/__init__.py
@@ -20,7 +20,7 @@ class FileMetadata(BaseModel):
 
 
 class ContextData(BaseModel):
-    dataset_id: int
+    index_id: int
     content: str
     metadata: Union[Optional[dict], FileMetadata] = Field(default=None)
 
@@ -49,4 +49,4 @@ class FunctionDescription(BaseModel):
     input_schema: Optional[Dict[str, Any]] = None
     out_schema: Optional[Dict[str, Any]] = None
     instructions: str
-    dataset_ids: Optional[List[int]] = None
+    index_ids: Optional[List[int]] = None


### PR DESCRIPTION
I was getting the following error after the rename from dataset to index:

```
Traceback (most recent call last):
  File "/Users/joch/dev/opper-ai/opper-teams-bot/src/bot.py", line 22, in on_message_activity
    response = await self.opper.functions.chat(
  File "/Users/joch/dev/opper-ai/opper-teams-bot/.venv/lib/python3.9/site-packages/opperai/functions/_async_functions.py", line 95, in chat
    return FunctionResponse(**response.json())
  File "/Users/joch/dev/opper-ai/opper-teams-bot/.venv/lib/python3.9/site-packages/pydantic/main.py", line 164, in __init__
    __pydantic_self__.__pydantic_validator__.validate_python(data, self_instance=__pydantic_self__)
pydantic_core._pydantic_core.ValidationError: 3 validation errors for FunctionResponse
context.0.dataset_id
  Field required [type=missing, input_value={'index_id': 532, 'conten...venska Bostäder.pdf'}}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.5/v/missing
context.1.dataset_id
  Field required [type=missing, input_value={'index_id': 532, 'conten...d distriktet (NY).pdf'}}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.5/v/missing
context.2.dataset_id
  Field required [type=missing, input_value={'index_id': 532, 'conten...a skeden (NY) (2).pdf'}}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.5/v/missing
```