### PR TITLE
feat: expose specific exception when structured generation fails

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opperai"
-version = "0.3.0"
+version = "0.3.1"
 description = "Opper Python client"
 authors = [
   {name = "Opper", email = "opper@opper.ai"},

--- a/src/opperai/functions/_functions.py
+++ b/src/opperai/functions/_functions.py
@@ -9,7 +9,12 @@ from opperai.types import (
     StreamingChunk,
     validate_id_xor_path,
 )
-from opperai.types.exceptions import APIError, RateLimitError
+from http import HTTPStatus
+from opperai.types.exceptions import (
+    APIError,
+    RateLimitError,
+    StructuredGenerationError,
+)
 
 
 class Functions:
@@ -35,7 +40,7 @@ class Functions:
             "/api/v1/functions",
             json={**function.model_dump(), **kwargs},
         )
-        if response.status_code != 200:
+        if response.status_code != HTTPStatus.OK:
             raise APIError(
                 f"Failed to create function {function.path} with status {response.status_code}: {response.text}"
             )
@@ -48,7 +53,7 @@ class Functions:
             f"/api/v1/functions/{function.id}",
             json={**function.model_dump(), **kwargs},
         )
-        if response.status_code != 200:
+        if response.status_code != HTTPStatus.OK:
             raise APIError(
                 f"Failed to update function `{function.path}` with status {response.status_code}: {response.text}"
             )
@@ -71,9 +76,9 @@ class Functions:
             "GET",
             f"/api/v1/functions/by_path/{function_path}",
         )
-        if response.status_code == 404:
+        if response.status_code == HTTPStatus.NOT_FOUND:
             return None
-        if response.status_code != 200:
+        if response.status_code != HTTPStatus.OK:
             raise APIError(
                 f"Failed to get function {function_path} with status {response.status_code}"
             )
@@ -85,9 +90,9 @@ class Functions:
             "GET",
             f"/api/v1/functions/{function_id}",
         )
-        if response.status_code == 404:
+        if response.status_code == HTTPStatus.NOT_FOUND:
             return None
-        if response.status_code != 200:
+        if response.status_code != HTTPStatus.OK:
             raise APIError(
                 f"Failed to get function {function_id} with status {response.status_code}"
             )
@@ -111,7 +116,7 @@ class Functions:
             "DELETE",
             f"/api/v1/functions/by_path/{function_path}",
         )
-        if response.status_code != 200:
+        if response.status_code != HTTPStatus.OK:
             raise APIError(
                 f"Failed to delete function {function_path} with status {response.status_code}"
             )
@@ -131,15 +136,17 @@ class Functions:
             f"/v1/chat/{function_path}",
             json={**serialized_data, **kwargs},
         )
-        if response.status_code == 429:
+
+        if response.status_code == HTTPStatus.OK:
+            return FunctionResponse.model_validate(response.json())
+        elif response.status_code == HTTPStatus.TOO_MANY_REQUESTS:
             raise RateLimitError("Rate limit error: please retry in a few seconds")
+        elif response.status_code == HTTPStatus.BAD_REQUEST:
+            raise StructuredGenerationError(response.text)
 
-        if response.status_code != 200:
-            raise APIError(
-                f"Failed to run function {function_path} with status {response.status_code}"
-            )
-
-        return FunctionResponse.model_validate(response.json())
+        raise APIError(
+            f"Failed to run function {function_path} with status {response.status_code}"
+        )
 
     def _chat_stream(
         self, function_path, data: ChatPayload, **kwargs
@@ -159,7 +166,7 @@ class Functions:
             "DELETE",
             f"/api/v1/functions/{id}/cache",
         )
-        if response.status_code != 204:
+        if response.status_code != HTTPStatus.NO_CONTENT:
             raise APIError(
                 f"Failed to flush cache for function with id={id} with status {response.status_code}"
             )

--- a/src/opperai/types/exceptions.py
+++ b/src/opperai/types/exceptions.py
@@ -4,3 +4,7 @@ class APIError(Exception):
 
 class RateLimitError(Exception):
     pass
+
+
+class StructuredGenerationError(Exception):
+    pass

--- a/tests/fixtures/vcr_cassettes/test_async_functions/test_failed_structured_generation.yaml
+++ b/tests/fixtures/vcr_cassettes/test_async_functions/test_failed_structured_generation.yaml
@@ -1,0 +1,200 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      user-agent:
+      - python-httpx/0.27.0
+    method: GET
+    uri: http://localhost:8000/api/v1/functions/by_path/test/sdk/test_failed_structured_generation
+  response:
+    body:
+      string: '{"id":15,"path":"test/sdk/test_failed_structured_generation","description":"test
+        structured generation exception","input_schema":null,"dataset_uuid":"87b2e30c-b5fc-4371-a131-3cd1586bf3b1","out_schema":{"type":"object","properties":{"universityName":{"type":"string"},"location":{"type":"string"},"departments":{"type":"array","items":{"type":"object","properties":{"departmentName":{"type":"string"},"head":{"type":"string"},"courses":{"type":"array","items":{"type":"object","properties":{"courseId":{"type":"string"},"courseName":{"type":"string"},"credits":{"type":"integer","minimum":1,"maximum":10}},"required":["courseId","courseName","credits"]}}},"required":["departmentName","head","courses"]}}},"required":["universityName","location","departments"]},"instructions":"You
+        translate the incoming text to french","use_semantic_search":false,"few_shot":false,"few_shot_count":2,"revision":2,"org_id":1,"index_ids":[],"linked_functions_ids":[],"model":"mistral/mistral-tiny-eu","language_model_id":4,"eval_summary":{"score":56,"generations_rated":13,"created_at":"2024-04-16T12:27:20.286125+00:00","improvements":"Instructions
+        should be clarified to remove potentially unprofessional terms and provide
+        a more specific schema for JSON output that aligns closely with the task of
+        translation. Specific fields should be clearly mentioned where the translated
+        text should appear to avoid confusion and ensure that the output is both correct
+        and professional-looking.","summary":"The model consistently translated ''hello''
+        into French correctly as either ''Bonjour'' or ''Salut''. However, there were
+        issues with adhering to JSON schema instructions. While some evaluations marked
+        the translations as correct with high scores, the use of terms like ''crap''
+        was flagged as unprofessional, and inappropriate values for certain JSON fields
+        were noted. Some evaluations indicated that the model either ignored the JSON
+        schema or used incorrect schemas unrelated to translation, affecting the task
+        performance negatively.","improved_instructions":"Translate the provided text
+        into French and return the translation in a JSON object using a professional
+        and appropriate key for the translated text. Example schema: { \"translation\":
+        \"translated text here\" }. Avoid use of unprofessional terms for keys and
+        ensure that the output strictly adheres to this schema."}}'
+    headers:
+      content-length:
+      - '2355'
+      content-type:
+      - application/json
+      date:
+      - Tue, 16 Apr 2024 12:29:06 GMT
+      server:
+      - uvicorn
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"id": 15, "path": "test/sdk/test_failed_structured_generation", "description":
+      "test structured generation exception", "input_schema": null, "out_schema":
+      {"type": "object", "properties": {"universityName": {"type": "string"}, "location":
+      {"type": "string"}, "departments": {"type": "array", "items": {"type": "object",
+      "properties": {"departmentName": {"type": "string"}, "head": {"type": "string"},
+      "courses": {"type": "array", "items": {"type": "object", "properties": {"courseId":
+      {"type": "string"}, "courseName": {"type": "string"}, "credits": {"type": "integer",
+      "minimum": 1, "maximum": 10}}, "required": ["courseId", "courseName", "credits"]}}},
+      "required": ["departmentName", "head", "courses"]}}}, "required": ["universityName",
+      "location", "departments"]}, "instructions": "You translate the incoming text
+      to french", "model": "mistral/mistral-tiny-eu", "index_ids": [], "use_semantic_search":
+      null, "few_shot": null, "few_shot_count": null, "cache_configuration": null}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '983'
+      content-type:
+      - application/json
+      user-agent:
+      - python-httpx/0.27.0
+    method: POST
+    uri: http://localhost:8000/api/v1/functions/15
+  response:
+    body:
+      string: '{"id":15,"path":"test/sdk/test_failed_structured_generation","description":"test
+        structured generation exception","input_schema":null,"out_schema":null,"instructions":"You
+        translate the incoming text to french","few_shot":false,"few_shot_count":2,"dataset_uuid":"87b2e30c-b5fc-4371-a131-3cd1586bf3b1","use_semantic_search":false,"model":"mistral/mistral-tiny-eu","language_model_id":4,"index_ids":[],"linked_function_ids":null,"revision":2,"cache_configuration":null}'
+    headers:
+      content-length:
+      - '467'
+      content-type:
+      - application/json
+      date:
+      - Tue, 16 Apr 2024 12:29:06 GMT
+      server:
+      - uvicorn
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"parent_span_uuid": null, "messages": [{"role": "user", "content": "hello"}]}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '78'
+      content-type:
+      - application/json
+      user-agent:
+      - python-httpx/0.27.0
+    method: POST
+    uri: http://localhost:8000/v1/chat/test/sdk/test_failed_structured_generation
+  response:
+    body:
+      string: '{"detail":"Structured generation failed, could not generate response
+        matching the schema."}'
+    headers:
+      content-length:
+      - '91'
+      content-type:
+      - application/json
+      date:
+      - Tue, 16 Apr 2024 12:29:06 GMT
+      server:
+      - uvicorn
+    status:
+      code: 400
+      message: Bad Request
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      user-agent:
+      - python-httpx/0.27.0
+    method: GET
+    uri: http://localhost:8000/api/v1/functions/15
+  response:
+    body:
+      string: '{"id":15,"path":"test/sdk/test_failed_structured_generation","description":"test
+        structured generation exception","input_schema":null,"dataset_uuid":"87b2e30c-b5fc-4371-a131-3cd1586bf3b1","out_schema":{"type":"object","properties":{"universityName":{"type":"string"},"location":{"type":"string"},"departments":{"type":"array","items":{"type":"object","properties":{"departmentName":{"type":"string"},"head":{"type":"string"},"courses":{"type":"array","items":{"type":"object","properties":{"courseId":{"type":"string"},"courseName":{"type":"string"},"credits":{"type":"integer","minimum":1,"maximum":10}},"required":["courseId","courseName","credits"]}}},"required":["departmentName","head","courses"]}}},"required":["universityName","location","departments"]},"instructions":"You
+        translate the incoming text to french","use_semantic_search":false,"few_shot":false,"few_shot_count":2,"revision":2,"org_id":1,"index_ids":[],"linked_functions_ids":[],"model":"mistral/mistral-tiny-eu","language_model_id":4,"eval_summary":{"score":56,"generations_rated":13,"created_at":"2024-04-16T12:27:20.286125+00:00","improvements":"Instructions
+        should be clarified to remove potentially unprofessional terms and provide
+        a more specific schema for JSON output that aligns closely with the task of
+        translation. Specific fields should be clearly mentioned where the translated
+        text should appear to avoid confusion and ensure that the output is both correct
+        and professional-looking.","summary":"The model consistently translated ''hello''
+        into French correctly as either ''Bonjour'' or ''Salut''. However, there were
+        issues with adhering to JSON schema instructions. While some evaluations marked
+        the translations as correct with high scores, the use of terms like ''crap''
+        was flagged as unprofessional, and inappropriate values for certain JSON fields
+        were noted. Some evaluations indicated that the model either ignored the JSON
+        schema or used incorrect schemas unrelated to translation, affecting the task
+        performance negatively.","improved_instructions":"Translate the provided text
+        into French and return the translation in a JSON object using a professional
+        and appropriate key for the translated text. Example schema: { \"translation\":
+        \"translated text here\" }. Avoid use of unprofessional terms for keys and
+        ensure that the output strictly adheres to this schema."}}'
+    headers:
+      content-length:
+      - '2355'
+      content-type:
+      - application/json
+      date:
+      - Tue, 16 Apr 2024 12:29:27 GMT
+      server:
+      - uvicorn
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      user-agent:
+      - python-httpx/0.27.0
+    method: DELETE
+    uri: http://localhost:8000/api/v1/functions/by_path/test/sdk/test_failed_structured_generation
+  response:
+    body:
+      string: '{"detail":"Function and associated generations deleted successfully"}'
+    headers:
+      content-length:
+      - '69'
+      content-type:
+      - application/json
+      date:
+      - Tue, 16 Apr 2024 12:29:27 GMT
+      server:
+      - uvicorn
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/vcr_cassettes/test_functions/test_failed_structured_generation.yaml
+++ b/tests/fixtures/vcr_cassettes/test_functions/test_failed_structured_generation.yaml
@@ -1,0 +1,166 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      user-agent:
+      - python-httpx/0.27.0
+    method: GET
+    uri: http://localhost:8000/api/v1/functions/by_path/test/sdk/test_failed_structured_generation
+  response:
+    body:
+      string: '{"detail":"Function not found"}'
+    headers:
+      content-length:
+      - '31'
+      content-type:
+      - application/json
+      date:
+      - Tue, 16 Apr 2024 12:32:53 GMT
+      server:
+      - uvicorn
+    status:
+      code: 404
+      message: Not Found
+- request:
+    body: '{"id": null, "path": "test/sdk/test_failed_structured_generation", "description":
+      "test structured generation exception", "input_schema": null, "out_schema":
+      {"type": "object", "properties": {"universityName": {"type": "string"}, "location":
+      {"type": "string"}, "departments": {"type": "array", "items": {"type": "object",
+      "properties": {"departmentName": {"type": "string"}, "head": {"type": "string"},
+      "courses": {"type": "array", "items": {"type": "object", "properties": {"courseId":
+      {"type": "string"}, "courseName": {"type": "string"}, "credits": {"type": "integer",
+      "minimum": 1, "maximum": 10}}, "required": ["courseId", "courseName", "credits"]}}},
+      "required": ["departmentName", "head", "courses"]}}}, "required": ["universityName",
+      "location", "departments"]}, "instructions": "You translate the incoming text
+      to french", "model": "mistral/mistral-tiny-eu", "index_ids": [], "use_semantic_search":
+      null, "few_shot": null, "few_shot_count": null, "cache_configuration": null}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '985'
+      content-type:
+      - application/json
+      user-agent:
+      - python-httpx/0.27.0
+    method: POST
+    uri: http://localhost:8000/api/v1/functions
+  response:
+    body:
+      string: '{"id":16,"path":"test/sdk/test_failed_structured_generation","description":"test
+        structured generation exception","input_schema":null,"out_schema":null,"instructions":"You
+        translate the incoming text to french","few_shot":false,"few_shot_count":2,"dataset_uuid":"b05b0393-7b71-4f2a-9f9c-05fcd202a0cc","use_semantic_search":false,"model":"mistral/mistral-tiny-eu","language_model_id":4,"index_ids":[],"linked_function_ids":null,"revision":1,"cache_configuration":null}'
+    headers:
+      content-length:
+      - '467'
+      content-type:
+      - application/json
+      date:
+      - Tue, 16 Apr 2024 12:32:53 GMT
+      server:
+      - uvicorn
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"parent_span_uuid": null, "messages": [{"role": "user", "content": "hello"}]}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '78'
+      content-type:
+      - application/json
+      user-agent:
+      - python-httpx/0.27.0
+    method: POST
+    uri: http://localhost:8000/v1/chat/test/sdk/test_failed_structured_generation
+  response:
+    body:
+      string: '{"detail":"Structured generation failed, could not generate response
+        matching the schema."}'
+    headers:
+      content-length:
+      - '91'
+      content-type:
+      - application/json
+      date:
+      - Tue, 16 Apr 2024 12:32:53 GMT
+      server:
+      - uvicorn
+    status:
+      code: 400
+      message: Bad Request
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      user-agent:
+      - python-httpx/0.27.0
+    method: GET
+    uri: http://localhost:8000/api/v1/functions/16
+  response:
+    body:
+      string: '{"id":16,"path":"test/sdk/test_failed_structured_generation","description":"test
+        structured generation exception","input_schema":null,"dataset_uuid":"b05b0393-7b71-4f2a-9f9c-05fcd202a0cc","out_schema":{"type":"object","properties":{"universityName":{"type":"string"},"location":{"type":"string"},"departments":{"type":"array","items":{"type":"object","properties":{"departmentName":{"type":"string"},"head":{"type":"string"},"courses":{"type":"array","items":{"type":"object","properties":{"courseId":{"type":"string"},"courseName":{"type":"string"},"credits":{"type":"integer","minimum":1,"maximum":10}},"required":["courseId","courseName","credits"]}}},"required":["departmentName","head","courses"]}}},"required":["universityName","location","departments"]},"instructions":"You
+        translate the incoming text to french","use_semantic_search":false,"few_shot":false,"few_shot_count":2,"revision":1,"org_id":1,"index_ids":[],"linked_functions_ids":[],"model":"mistral/mistral-tiny-eu","language_model_id":4}'
+    headers:
+      content-length:
+      - '1005'
+      content-type:
+      - application/json
+      date:
+      - Tue, 16 Apr 2024 12:33:02 GMT
+      server:
+      - uvicorn
+    status:
+      code: 200
+      message: OK
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      user-agent:
+      - python-httpx/0.27.0
+    method: DELETE
+    uri: http://localhost:8000/api/v1/functions/by_path/test/sdk/test_failed_structured_generation
+  response:
+    body:
+      string: '{"detail":"Function and associated generations deleted successfully"}'
+    headers:
+      content-length:
+      - '69'
+      content-type:
+      - application/json
+      date:
+      - Tue, 16 Apr 2024 12:33:02 GMT
+      server:
+      - uvicorn
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
When there is a status 400 when calling a function we raise a `StructuredGenerationError` that the user can catch.