### PR TITLE
fix: schema generation failed on list of pydantic models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "opperai"
-version = "0.3.3"
+version = "0.3.4"
 description = "Opper Python client"
 authors = [
   {name = "Opper", email = "opper@opper.ai"},
@@ -32,7 +32,8 @@ test = [
     "pytest",
     "pytest-asyncio",
     "pytest-cov",
-    "vcrpy"
+    "vcrpy",
+    "jsonschema"
 ]
 
 


### PR DESCRIPTION
The fix takes an extra pass on the generated schema and lifts definitions to the top level of the schema.