### PR TITLE
Set pydantic v2 as a requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ packages = [{include = "opperai", from = "src"}]
 
 [tool.poetry.dependencies]
 python = "^3.9"
-pydantic = "*"
+pydantic = ">=2"
 httpx = "0.27.0"
 httpx-sse = "0.4.0"
 


### PR DESCRIPTION
If trying to use the Opper package with Pydantic v1, it fails:

```
ImportError: cannot import name 'computed_field' from 'pydantic'
```

here: https://github.com/opper-ai/opper-python/blob/main/src/opperai/types/__init__.py#L10

This is only available starting on v2